### PR TITLE
Add angle limits for triangles

### DIFF
--- a/Common/Maths/Coordinates/2D/GloXYPointOperations.cs
+++ b/Common/Maths/Coordinates/2D/GloXYPointOperations.cs
@@ -41,7 +41,9 @@ public static class GloXYPointOperations
     // --------------------------------------------------------------------------------------------
 
 
-    // Given 3 points, ABC forming to lines AB and BC, find the angle between them.
+    // Given 3 points ABC representing two lines AB and BC, return the clockwise
+    // angle from BA to BC in radians. The result is normalized to the range
+    // [0, 2π).
 
     public static double AngleBetweenRads(GloXYPoint a, GloXYPoint b, GloXYPoint c)
     {

--- a/Common/Maths/Coordinates/2D/GloXYTriangle.cs
+++ b/Common/Maths/Coordinates/2D/GloXYTriangle.cs
@@ -13,6 +13,27 @@ public struct GloXYTriangle
     public GloXYLine LineBC => new GloXYLine(B, C);
     public GloXYLine LineCA => new GloXYLine(C, A);
 
+    // -------------------------------------------------------------------------------
+    // MARK: Angle Properties
+    // -------------------------------------------------------------------------------
+
+    private static double InternalAngle(GloXYPoint prev, GloXYPoint vertex, GloXYPoint next)
+    {
+        double angle = GloXYPointOperations.AngleBetweenRads(prev, vertex, next);
+        if (angle > Math.PI)
+            angle = (2 * Math.PI) - angle; // convert reflex angle to internal
+        return GloDoubleRange.ZeroToPiRadians.Apply(angle);
+    }
+
+    // Internal angle at the corner formed by AB -> BC
+    public double InternalAngleABRads() => InternalAngle(A, B, C);
+
+    // Internal angle at the corner formed by BC -> CA
+    public double InternalAngleBCRads() => InternalAngle(B, C, A);
+
+    // Internal angle at the corner formed by CA -> AB
+    public double InternalAngleCARads() => InternalAngle(C, A, B);
+
     // --------------------------------------------------------------------------------------------
     // MARK: Constructors
     // --------------------------------------------------------------------------------------------

--- a/Common/Maths/Numeric/GloNumericRange.cs
+++ b/Common/Maths/Numeric/GloNumericRange.cs
@@ -32,6 +32,7 @@ public class GloNumericRange<T> where T : INumber<T>
     public static readonly GloNumericRange<T> ZeroTo360Degrees     = new GloNumericRange<T>(T.CreateChecked(0),    T.CreateChecked(360), RangeBehavior.Wrap);
     public static readonly GloNumericRange<T> Minus180To180Degrees = new GloNumericRange<T>(T.CreateChecked(-180), T.CreateChecked(180), RangeBehavior.Wrap);
     public static readonly GloNumericRange<T> ZeroToTwoPiRadians   = new GloNumericRange<T>(T.CreateChecked(0),    GloConsts<T>.kTwoPi,  RangeBehavior.Wrap);
+    public static readonly GloNumericRange<T> ZeroToPiRadians      = new GloNumericRange<T>(T.CreateChecked(0),    GloConsts<T>.kPi,     RangeBehavior.Wrap);
     public static readonly GloNumericRange<T> MinusPiToPiRadians   = new GloNumericRange<T>(-GloConsts<T>.kPi,     GloConsts<T>.kPi,     RangeBehavior.Limit);
 
     // --------------------------------------------------------------------------------------------

--- a/UnitTest/GloTestCenter.cs
+++ b/UnitTest/GloTestCenter.cs
@@ -11,6 +11,7 @@ public static class GloTestCenter
             GloTestMath.RunTests(testLog);
             GloTestXYZVector.RunTests(testLog);
             GloTestLine.RunTests(testLog);
+            GloTestTriangle.RunTests(testLog);
 
             GloTestPosition.RunTests(testLog);
             GloTestPositionLLA.RunTests(testLog);

--- a/UnitTest/Maths/GloTestTriangle.cs
+++ b/UnitTest/Maths/GloTestTriangle.cs
@@ -1,0 +1,32 @@
+using System;
+
+public static class GloTestTriangle
+{
+    public static void RunTests(GloTestLog testLog)
+    {
+        try
+        {
+            TestInternalAnglesSum(testLog);
+        }
+        catch (Exception ex)
+        {
+            testLog.AddResult("GloTestTriangle RunTests", false, ex.Message);
+        }
+    }
+
+    private static void TestInternalAnglesSum(GloTestLog testLog)
+    {
+        var tri = new GloXYTriangle(new GloXYPoint(0, 0), new GloXYPoint(1, 0), new GloXYPoint(0, 1));
+
+        double angAB = tri.InternalAngleABRads();
+        double angBC = tri.InternalAngleBCRads();
+        double angCA = tri.InternalAngleCARads();
+        double sum = angAB + angBC + angCA;
+
+        bool withinRange = GloDoubleRange.ZeroToPiRadians.IsInRange(angAB) &&
+                           GloDoubleRange.ZeroToPiRadians.IsInRange(angBC) &&
+                           GloDoubleRange.ZeroToPiRadians.IsInRange(angCA);
+        testLog.AddResult("GloXYTriangle Angles < π", withinRange);
+        testLog.AddResult("GloXYTriangle Angles Sum", GloValueUtils.EqualsWithinTolerance(sum, Math.PI));
+    }
+}


### PR DESCRIPTION
## Summary
- document the range for `AngleBetweenRads`
- add `ZeroToPiRadians` numeric range constant
- clamp triangle internal angles using the new range
- validate internal angle ranges in `GloTestTriangle`

## Testing
- `dotnet run`

------
https://chatgpt.com/codex/tasks/task_e_6852cb7f0d58832c8e704a674e276a56