### PR TITLE
Implement route leg base and simple turn

### DIFF
--- a/Common/Position/Route/GloRouteSimpleTurn.cs
+++ b/Common/Position/Route/GloRouteSimpleTurn.cs
@@ -1,136 +1,81 @@
-// Class to define a simple route turn, a circular arc defined by a start point, a turn point, and a delta angle (that can be plus or minus), but generally
-// defined by the turn point being perpendicular to the start point and a distance away (that defines the radius of the turn).
+using System;
 
-public class GloRouteSimpleTurn
+// Simple turn leg following a circular arc defined by a start point,
+// a turn centre point and an angular change.
+public class GloRouteSimpleTurn : IGloRouteLeg
 {
-    // public GloLLAPoint StartPoint { get; set; }
-    // public GloLLAPoint TurnPoint { get; set; }
-    // public double DeltaAngleRads { get; set; } // Positive for right turn, negative for left turn
+    public GloLLAPoint TurnPoint { get; set; }
+    public double      DeltaAngleRads { get; set; }
+    public double      SpeedMps { get; set; }
 
-    // // Define values useful to traversing the turn
-    // public double DistancePerSecondM { get; set; } // Speed through the turn
+    // ------------------------------------------------------------------
+    public double DeltaAngleDegs
+    {
+        get => DeltaAngleRads * GloConsts.RadsToDegsMultiplier;
+        set => DeltaAngleRads = value * GloConsts.DegsToRadsMultiplier;
+    }
 
-    // // ----------------------------------------------------------------------------------------------
+    public GloRouteSimpleTurn(GloLLAPoint startPoint, GloLLAPoint turnPoint, double deltaAngleRads, double speedMps)
+    {
+        StartPoint     = startPoint;
+        TurnPoint      = turnPoint;
+        DeltaAngleRads = deltaAngleRads;
+        SpeedMps       = speedMps;
+        Setup();
+    }
 
-    // public double DeltaAngleDegs
-    // {
-    //     get => GloValueUtils.RadsToDegs(DeltaAngleRads);
-    //     set => DeltaAngleRads = GloValueUtils.DegsToRads(value);
-    // }
+    private void Setup()
+    {
+        double radius = TurnRadiusM();
+        double startBearing = TurnPoint.BearingToRads(StartPoint);
+        double endBearing   = startBearing + DeltaAngleRads;
 
-    // // ----------------------------------------------------------------------------------------------
+        EndPoint = TurnPoint.PlusRangeBearing(new GloRangeBearing(radius, endBearing));
 
-    // // Constructor
-    // public GloRouteSimpleTurn(GloLLAPoint startPoint, GloLLAPoint turnPoint, double deltaAngleRads)
-    // {
-    //     StartPoint = startPoint;
-    //     TurnPoint = turnPoint;
-    //     DeltaAngleRads = deltaAngleRads;
-    // }
+        double startHeading = startBearing + (DeltaAngleRads > 0 ? Math.PI / 2 : -Math.PI / 2);
+        double endHeading   = endBearing   + (DeltaAngleRads > 0 ? Math.PI / 2 : -Math.PI / 2);
 
-    // // ----------------------------------------------------------------------------------------------
+        StartCourse = new GloCourse() { SpeedMps = SpeedMps, HeadingRads = startHeading, ClimbRateMps = 0 };
+        EndCourse   = new GloCourse() { SpeedMps = SpeedMps, HeadingRads = endHeading, ClimbRateMps = 0 };
 
-    // public double TurnRadiusM()
-    // {
-    //     // Calculate the radius of the turn based on the distance from the start point to the turn point
-    //     double distance = StartPoint.StraightLineDistanceToM(TurnPoint);
-    //     return distance / Math.Abs(Math.Sin(DeltaAngleRads / 2));
-    // }
+        StartAttitude      = GloAttitude.Zero;
+        EndAttitude        = GloAttitude.Zero;
+        StartAttitudeDelta = GloAttitudeDelta.Zero;
+        EndAttitudeDelta   = GloAttitudeDelta.Zero;
+    }
 
-    // public double TurnLengthM()
-    // {
-    //     // Calculate the length of the turn arc
-    //     double radius = TurnRadiusM();
-    //     return Math.Abs(DeltaAngleRads) * radius;
-    // }
+    // Radius from centre to start
+    public double TurnRadiusM() => TurnPoint.CurvedDistanceToM(StartPoint);
 
-    // public double TurnDurationSecs()
-    // {
-    //     // Calculate the duration of the turn based on the length of the turn and the speed through the turn
-    //     double length = TurnLengthM();
-    //     return length / DistancePerSecondM;
-    // }
+    public double TurnLengthM() => Math.Abs(DeltaAngleRads) * TurnRadiusM();
 
-    // // Return the direction of travel and the end of the turn, to help inform the next leg of the route.
-    // public GloCourse LegEndCourse()
-    // {
-    //     // Calculate the range and bearing from the start point to the turn point
-    //     double rangeM = StartPoint.StraightLineDistanceToM(TurnPoint);
-    //     double bearingRads = StartPoint.BearingToRads(TurnPoint);
+    public double TurnDurationSecs() => (SpeedMps < GloConsts.ArbitraryMinDouble) ? 0 : TurnLengthM() / SpeedMps;
 
-    //     // Create a GloCourse object for the turn end point
-    //     return new GloCourse()
-    //     {
-    //         SpeedMps = DistancePerSecondM,
-    //         HeadingRads = bearingRads,
-    //         ClimbRateMps = 0.0 // Assuming no vertical component for the turn
-    //     };
-    // }
+    public override double GetCalculatedDistanceM() => TurnLengthM();
 
-    // // ----------------------------------------------------------------------------------------------
+    public override double GetDurationS() => TurnDurationSecs();
 
-    // // Using a time for 0 at the start of the turn, calculate the position at a specific time during the turn.
+    private GloLLAPoint PositionAtTurnFraction(double fraction)
+    {
+        fraction = GloDoubleRange.ZeroToOne.Apply(fraction);
+        double startBearing = TurnPoint.BearingToRads(StartPoint);
+        double angle = startBearing + DeltaAngleRads * fraction;
+        return TurnPoint.PlusRangeBearing(new GloRangeBearing(TurnRadiusM(), angle));
+    }
 
-    // public GloLLAPoint PositionAtTurnTime(double turnTimeS)
-    // {
-    //     // Calculate the fraction of the turn completed
-    //     double fraction = turnTimeS / TurnDurationSecs();
+    public override GloLLAPoint PositionAtLegTime(double legtimeS)
+    {
+        double frac = (GetDurationS() > 0) ? legtimeS / GetDurationS() : 0;
+        return PositionAtTurnFraction(frac);
+    }
 
-    //     // Ensure the fraction is within the valid range
-    //     fraction = GloNumericRange<double>.ZeroToOne.Apply(fraction);
-
-    //     // Delegate to PositionAtTurnFraction for the actual position calculation
-    //     return PositionAtTurnFraction(fraction);
-    // }
-
-    // // Find the position at a specific fraction of the turn duration, where 0 is the start of the turn and 1 is the end of the turn.
-    // // Useful when drawing the route in X segments.
-
-    // public GloLLAPoint PositionAtTurnFraction(double turnFraction)
-    // {
-    //     // Ensure the fraction is within the valid range
-    //     turnFraction = GloNumericRange<double>.ZeroToOne.Apply(turnFraction);
-
-    //     // Calculate the time at the given fraction of the turn duration
-    //     double turnTimeS = TurnDurationSecs() * turnFraction;
-
-    //     return PositionAtTurnTime(turnTimeS);
-    // }
-
-    // // ----------------------------------------------------------------------------------------------
-
-    // // Static method to help define a new turn, based on a previous leg.
-    // // - We use the leg direction, plus a perpendicular direction to the leg, to find the turn point.
-
-    // public static GloLLAPoint FindTurnPoint(GloLLAPoint prevLegStartPoint, GloLLAPoint prevLegEndPoint, double turnRadiusM, double deltaAngleRads)
-    // {
-    //     // Calculate the leg direction
-    //     double legDirectionRads = prevLegStartPoint.BearingToRads(prevLegEndPoint);
-
-    //     double perpendicularAngleRads = 0;
-
-    //     // Determine the turn direction based on the delta angle
-    //     // If delta angle is positive, we turn right (clockwise), if negative, we turn left (counter-clockwise).
-    //     // We add the delta angle to the leg direction to find the turn direction.
-    //     if (deltaAngleRads > 0)
-    //     {
-    //         // Right turn
-    //         perpendicularAngleRads = (Math.PI / 2);
-    //     }
-    //     else
-    //     {
-    //         // Left turn
-    //         perpendicularAngleRads = -(Math.PI / 2);
-    //     }
-
-    //     // Find the angle from the previous leg end point to the turn point.
-    //     // This is the leg direction plus the perpendicular angle (with the perpendicular angle being defined by the turn direction).
-    //     double endPointBearingToTurnPoint = GloNumericRange<double>.ZeroToTwoPiRadians.Apply(legDirectionRads + perpendicularAngleRads);
-
-    //     GloRangeBearing rbToTurnPoint = new GloRangeBearing(turnRadiusM, endPointBearingToTurnPoint);
-
-    //     return prevLegEndPoint.PlusRangeBearing(rbToTurnPoint);
-    // }
-
+    public override GloCourse CourseAtLegTime(double legtimeS)
+    {
+        double frac = (GetDurationS() > 0) ? legtimeS / GetDurationS() : 0;
+        frac = GloDoubleRange.ZeroToOne.Apply(frac);
+        double startBearing = TurnPoint.BearingToRads(StartPoint);
+        double angle = startBearing + DeltaAngleRads * frac;
+        double heading = angle + (DeltaAngleRads > 0 ? Math.PI / 2 : -Math.PI / 2);
+        return new GloCourse() { SpeedMps = SpeedMps, HeadingRads = GloDoubleRange.ZeroToTwoPiRadians.Apply(heading), ClimbRateMps = 0 };
+    }
 }
-

--- a/Common/Position/Route/IGloRouteLeg.cs
+++ b/Common/Position/Route/IGloRouteLeg.cs
@@ -1,69 +1,74 @@
+using System;
 
-// Route legs are the building blocks of a route. They are the segments of the route that connect two points.
-// We need operations to establish the entry and exit crietia of each leg and the position/attitude along it to
-// control the platform.
-
-// *TIME*: A route leg calculates its duration. Time for overall route position is the route class responsibility,
-// not the leg. So all times are for a zero start time duration, not an overall scenario or route time.
-
-public interface IGloRouteLeg
+// Abstract base class for route legs. Provides common properties and helper
+// functions that can be used by all leg types.
+public abstract class IGloRouteLeg
 {
-    // --------------------------------------------------------------------------------------------
-    // MARK: Properties around the ends of a leg
-    // --------------------------------------------------------------------------------------------
-
-    // Position Operations
+    // End points
     public GloLLAPoint StartPoint { get; set; }
     public GloLLAPoint EndPoint   { get; set; }
 
-    // Course Operations
-    public GloCourse StartCourse { get; }
-    public GloCourse EndCourse   { get; }
+    // Course information
+    public GloCourse StartCourse { get; protected set; } = GloCourse.Zero;
+    public GloCourse EndCourse   { get; protected set; } = GloCourse.Zero;
 
-    // Attitude Operations
-    public GloAttitude StartAttitude { get; }
-    public GloAttitude EndAttitude   { get; }
+    // Attitude information
+    public GloAttitude StartAttitude { get; protected set; } = GloAttitude.Zero;
+    public GloAttitude EndAttitude   { get; protected set; } = GloAttitude.Zero;
 
-    // Attitude Delta Operations
-    public GloAttitudeDelta StartAttitudeDelta { get; }
-    public GloAttitudeDelta EndAttitudeDelta   { get; }
+    // Attitude delta information
+    public GloAttitudeDelta StartAttitudeDelta { get; protected set; } = GloAttitudeDelta.Zero;
+    public GloAttitudeDelta EndAttitudeDelta   { get; protected set; } = GloAttitudeDelta.Zero;
 
-    // Methods ordered by increasing derivatives, starting with position, velocity, acceleration, and so on.
+    // ---------------------------------------------------------------------
+    // MARK: Distances
+    // ---------------------------------------------------------------------
 
-    // --------------------------------------------------------------------------------------------
-    // MARK: Position and Distance
-    // --------------------------------------------------------------------------------------------
+    // Straight line distance between the start and end points
+    public virtual double GetStraightLineDistanceM() => StartPoint.CurvedDistanceToM(EndPoint);
 
-    public GloLLAPoint PositionAtLegTime(double legtimeS) => GloLLAPoint.Zero;
-    public double      GetStraightLineDistanceM() => 0f;
+    // Calculated distance along the leg path. Default is straight line distance.
+    public virtual double GetCalculatedDistanceM() => GetStraightLineDistanceM();
 
-    public double GetCalculatedDistanceM() => GetStraightLineDistanceM();
-
-
-    // --------------------------------------------------------------------------------------------
+    // ---------------------------------------------------------------------
     // MARK: Time
-    // --------------------------------------------------------------------------------------------
+    // ---------------------------------------------------------------------
 
-    public float GetDurationS() => 0f;
+    public abstract double GetDurationS();
 
-    // --------------------------------------------------------------------------------------------
-    // MARK: Course
-    // --------------------------------------------------------------------------------------------
+    // ---------------------------------------------------------------------
+    // MARK: Position and derivatives
+    // ---------------------------------------------------------------------
 
-    public GloCourse CourseAtLegTime(double legtimeS) => GloCourse.Zero;
+    public abstract GloLLAPoint PositionAtLegTime(double legtimeS);
 
-    // --------------------------------------------------------------------------------------------
-    // MARK: Attitude
-    // --------------------------------------------------------------------------------------------
+    public virtual GloLLAPoint PositionAtLegFraction(double fraction)
+    {
+        double t = GetDurationS() * GloDoubleRange.ZeroToOne.Apply(fraction);
+        return PositionAtLegTime(t);
+    }
 
-    public GloAttitude AttitudeAtLegTime(double legtimeS) => GloAttitude.Zero;
+    public virtual GloCourse CourseAtLegTime(double legtimeS) => StartCourse;
 
-    // --------------------------------------------------------------------------------------------
-    // MARK: Attitude Delta
-    // --------------------------------------------------------------------------------------------
+    public virtual GloCourse CourseAtLegFraction(double fraction)
+    {
+        double t = GetDurationS() * GloDoubleRange.ZeroToOne.Apply(fraction);
+        return CourseAtLegTime(t);
+    }
 
-    public GloAttitudeDelta AttitudeDeltaAtLegTime(double legtimeS) => GloAttitudeDelta.Zero;
+    public virtual GloAttitude AttitudeAtLegTime(double legtimeS) => StartAttitude;
 
+    public virtual GloAttitude AttitudeAtLegFraction(double fraction)
+    {
+        double t = GetDurationS() * GloDoubleRange.ZeroToOne.Apply(fraction);
+        return AttitudeAtLegTime(t);
+    }
+
+    public virtual GloAttitudeDelta AttitudeDeltaAtLegTime(double legtimeS) => StartAttitudeDelta;
+
+    public virtual GloAttitudeDelta AttitudeDeltaAtLegFraction(double fraction)
+    {
+        double t = GetDurationS() * GloDoubleRange.ZeroToOne.Apply(fraction);
+        return AttitudeDeltaAtLegTime(t);
+    }
 }
-
-

--- a/UnitTest/GloTestCenter.cs
+++ b/UnitTest/GloTestCenter.cs
@@ -15,6 +15,7 @@ public static class GloTestCenter
 
             GloTestPosition.RunTests(testLog);
             GloTestPositionLLA.RunTests(testLog);
+            GloTestRoute.RunTests(testLog);
             //GloTestPlotter.RunTests(testLog);
             GloTestList1D.RunTests(testLog);
             GloTestList2D.RunTests(testLog);

--- a/UnitTest/Position/GloTestRoute.cs
+++ b/UnitTest/Position/GloTestRoute.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+
+public static class GloTestRoute
+{
+    public static void RunTests(GloTestLog testLog)
+    {
+        try
+        {
+            TestSimpleRoute(testLog);
+        }
+        catch (Exception ex)
+        {
+            testLog.AddResult("GloTestRoute RunTests", false, ex.Message);
+        }
+    }
+
+    private static void TestSimpleRoute(GloTestLog testLog)
+    {
+        // Build two legs: a straight line followed by a 90 degree right turn
+        GloLLAPoint start = new GloLLAPoint() { LatDegs = 0, LonDegs = 0, AltMslM = 0 };
+        GloLLAPoint mid = start.PlusRangeBearing(new GloRangeBearing(1000, 90 * GloConsts.DegsToRadsMultiplier));
+
+        double speed = 100; // m/s
+        var leg1 = new GloRouteLegLine(start, mid, speed);
+
+        // Turn centre 500 m to the right of mid point
+        double centreBearing = GloDoubleRange.ZeroToTwoPiRadians.Apply(leg1.EndCourse.HeadingRads + Math.PI / 2);
+        GloLLAPoint centre = mid.PlusRangeBearing(new GloRangeBearing(500, centreBearing));
+
+        var turnLeg = new GloRouteSimpleTurn(mid, centre, Math.PI / 2, speed);
+
+        var route = new GloRoute(new List<IGloRouteLeg>() { leg1, turnLeg });
+
+        testLog.AddResult("Route NumLegs", route.NumLegs() == 2);
+
+        double expectedDuration = leg1.GetDurationS() + turnLeg.GetDurationS();
+        bool durOk = GloValueUtils.EqualsWithinTolerance(route.GetDurationSeconds(), expectedDuration, 0.001);
+        testLog.AddResult("Route Duration", durOk);
+
+        GloLLAPoint midOfLine = route.CurrentPosition(leg1.GetDurationS() / 2);
+        GloLLAPoint expectedMid = GloLLAPointOperations.RhumbLineInterpolation(start, mid, 0.5);
+        bool midLat = GloValueUtils.EqualsWithinTolerance(midOfLine.LatDegs, expectedMid.LatDegs, 0.0001);
+        bool midLon = GloValueUtils.EqualsWithinTolerance(midOfLine.LonDegs, expectedMid.LonDegs, 0.0001);
+        testLog.AddResult("Route Line MidPos", midLat && midLon);
+
+        GloLLAPoint endPos = route.CurrentPosition(expectedDuration);
+        bool endLat = GloValueUtils.EqualsWithinTolerance(endPos.LatDegs, turnLeg.EndPoint.LatDegs, 0.0001);
+        bool endLon = GloValueUtils.EqualsWithinTolerance(endPos.LonDegs, turnLeg.EndPoint.LonDegs, 0.0001);
+        testLog.AddResult("Route EndPos", endLat && endLon);
+
+        GloLLAPoint midTurnPos = route.CurrentPosition(leg1.GetDurationS() + turnLeg.GetDurationS() / 2);
+        GloLLAPoint expectedMidTurn = turnLeg.PositionAtLegFraction(0.5);
+        bool mtLat = GloValueUtils.EqualsWithinTolerance(midTurnPos.LatDegs, expectedMidTurn.LatDegs, 0.0001);
+        bool mtLon = GloValueUtils.EqualsWithinTolerance(midTurnPos.LonDegs, expectedMidTurn.LonDegs, 0.0001);
+        testLog.AddResult("Route Turn MidPos", mtLat && mtLon);
+    }
+}


### PR DESCRIPTION
## Summary
- convert IGloRouteLeg to an abstract base class with fraction helpers
- rebuild GloRouteLegLine to use the base class
- implement functional GloRouteSimpleTurn
- add route unit tests and hook them into the test centre

## Testing
- `dotnet build`
- `dotnet run --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6855381a5d00832ca76da71aff34de7c