### PR TITLE
Fix altitude in range bearing

### DIFF
--- a/Common/Position/GloLLAPoint.cs
+++ b/Common/Position/GloLLAPoint.cs
@@ -277,7 +277,13 @@ public struct GloLLAPoint
         double a = Math.Pow(Math.Sin(dLat / 2), 2) +
                 Math.Cos(lat1) * Math.Cos(lat2) * Math.Pow(Math.Sin(dLon / 2), 2);
 
-        double distanceM = 2 * GloWorldConsts.EarthRadiusM * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a)); // in meters
+        // Use the mean radius of the two points so that the returned range is
+        // consistent with PlusRangeBearing() which operates at the point's
+        // altitude.  Using the plain earth radius here caused small errors when
+        // the caller expected altitude to be taken into account.
+        double calcRadius = (this.RadiusM + destPos.RadiusM) / 2.0;
+
+        double distanceM = 2 * calcRadius * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
 
         // Calculate bearing
         double y = Math.Sin(dLon) * Math.Cos(lat2);


### PR DESCRIPTION
## Summary
- adjust `RangeBearingTo` to use the mean radius of both points
- update unit test results

## Testing
- `dotnet build`
- `dotnet run --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685a9b585e08832c82ac221789091150